### PR TITLE
Bubble Minigame: Gameplay fixes

### DIFF
--- a/Assets/Scripts/BlowingBubble.cs
+++ b/Assets/Scripts/BlowingBubble.cs
@@ -74,7 +74,7 @@ public class BlowingBubble : MonoBehaviour
 
     private void FixedUpdate()
     {
-        if (!gameWon)
+        if (gameActive && !gameWon)
         {
             //Updates the Timer
             timer -= Time.fixedDeltaTime;
@@ -161,6 +161,7 @@ public class BlowingBubble : MonoBehaviour
     public void RightClick()
     {
         Debug.Log("OnButtonPress");
+        gameActive = true;
         //Checks to see if the game has been one
         if (gameWon)
         {
@@ -179,6 +180,7 @@ public class BlowingBubble : MonoBehaviour
         if (bubbleObject.transform.localScale.x >= targetSize)
         {
             gameWon = true;
+            gameActive = false;
             ShowWinPopup();
         }
     }

--- a/Assets/Scripts/BlowingBubble.cs
+++ b/Assets/Scripts/BlowingBubble.cs
@@ -13,6 +13,7 @@ public class BlowingBubble : MonoBehaviour
 
     //Declaring the bubble object
     public GameObject bubbleObject;
+    public float originalBubbleSize = 1.0f;
     public float maxBubbleSize = 3.0f;
 
     //Declaring the timer variables to account for dynamic difficulty
@@ -40,6 +41,7 @@ public class BlowingBubble : MonoBehaviour
     public Button nextButton;
 
     //Declaring the Text Variables
+    public float bubbleProgress;
     public TextMeshProUGUI bubbleProgressText;
     public TextMeshProUGUI timerText;
 
@@ -48,7 +50,10 @@ public class BlowingBubble : MonoBehaviour
     {
         //Establishes that the original timer is equal to the timer variable
         originalTimer = timer;
+        
+        bubbleObject.transform.localScale = Vector3.one * originalBubbleSize;
         setupNewRound();
+        SetBubbleProgressText();
     }
 
     void Update()
@@ -70,14 +75,12 @@ public class BlowingBubble : MonoBehaviour
 
 
             //Checks to see if the User clicked the Button
-            if (Input.GetMouseButton(0))
+            if (Input.GetMouseButtonDown(0))
             {
                 RightClick();
+                //Updates the Bubble Percentage Text
+                SetBubbleProgressText();
             }
-
-            //Updates the Bubble Percentage Text
-            float bubbleProgress = (bubbleObject.transform.localScale.x / targetSize) * 100f;
-            bubbleProgressText.text = "Bubble Progress: " + Mathf.Min(bubbleProgress, 100f).ToString("F1") + "%";
         }
     }
 
@@ -120,6 +123,8 @@ public class BlowingBubble : MonoBehaviour
     //Sets up the first round of the minigame
     void setupNewRound()
     {
+        bubbleProgress = 0f;
+
         //Will reset the bubble size
         bubbleObject.transform.localScale = Vector3.one * 0.1f;
 
@@ -128,7 +133,8 @@ public class BlowingBubble : MonoBehaviour
         PlayerPrefs.SetFloat("castSize", castSize);
 
         //Determine the target Bubble position
-        targetSize = Mathf.Min(castSize * (2.0f / 3.0f), maxBubbleSize);
+        //targetSize = Mathf.Min(castSize * (2.0f / 3.0f), maxBubbleSize);
+        targetSize = maxBubbleSize;
 
         //Resets the Timer 
         timer = originalTimer;
@@ -169,6 +175,15 @@ public class BlowingBubble : MonoBehaviour
             gameWon = true;
             ShowWinPopup();
         }
+    }
+
+    public void SetBubbleProgressText()
+    {
+        bubbleProgress = 
+            ((bubbleObject.transform.localScale.x) - (originalBubbleSize))
+            /
+            (targetSize - originalBubbleSize) * 100f;
+        bubbleProgressText.text = "Bubble Progress: " + Mathf.Min(bubbleProgress, 100f).ToString("F1") + "%";
     }
 
     //Centering the Runaway Bubble

--- a/Assets/Scripts/BlowingBubble.cs
+++ b/Assets/Scripts/BlowingBubble.cs
@@ -26,6 +26,7 @@ public class BlowingBubble : MonoBehaviour
 
     //Boolean to check to see if the Game has been won
     private bool gameWon = false;
+    private bool gameActive = false; // activated once player clicks for the first time
 
     //Declaring the variables for the popup Window
     public GameObject winPopup;
@@ -61,8 +62,22 @@ public class BlowingBubble : MonoBehaviour
         //A continual loop to check to see if the user has one the game. 
         if (!gameWon)
         {
+            //Checks to see if the User clicked the Button
+            if (Input.GetMouseButtonDown(0))
+            {
+                RightClick();
+                //Updates the Bubble Percentage Text
+                SetBubbleProgressText();
+            }
+        }
+    }
+
+    private void FixedUpdate()
+    {
+        if (!gameWon)
+        {
             //Updates the Timer
-            timer -= Time.deltaTime;
+            timer -= Time.fixedDeltaTime;
 
             //Checks to see if the timer is 0
             if (timer <= 0)
@@ -71,16 +86,7 @@ public class BlowingBubble : MonoBehaviour
             }
 
             //Updates the timer text
-            timerText.text = "Time: " +  Mathf.Max(0, timer).ToString("F1");
-
-
-            //Checks to see if the User clicked the Button
-            if (Input.GetMouseButtonDown(0))
-            {
-                RightClick();
-                //Updates the Bubble Percentage Text
-                SetBubbleProgressText();
-            }
+            timerText.text = "Time: " + Mathf.Max(0, timer).ToString("F1");
         }
     }
 


### PR DESCRIPTION
Made the following gameplay fixes to the Bubble Minigame:
* The progress bar starts at 0%
* Prevented the game from ending prematurely
* The game doesn't start until the player clicks once

Note:
Since the BubbleMinigame is also being converted into a prefab by another member, I didn't commit any of my changes to the scene. In order to test this PR:
* Set the Canvas' render mode to Screen Space - Overlay
* Assign the Render Camera to the Main Camera